### PR TITLE
add free_temporary_memory() dummy for compatibility

### DIFF
--- a/dpcpp_bindings/tiny_dpcpp_nn/__init__.py
+++ b/dpcpp_bindings/tiny_dpcpp_nn/__init__.py
@@ -1,7 +1,8 @@
 from .modules import (
+    free_temporary_memory,
     NetworkWithInputEncoding,
     Network,
     Encoding,
 )
 
-__all__ = ["NetworkWithInputEncoding", "Network", "Encoding"]
+__all__ = ["free_temporary_memory", "NetworkWithInputEncoding", "Network", "Encoding"]

--- a/dpcpp_bindings/tiny_dpcpp_nn/modules.py
+++ b/dpcpp_bindings/tiny_dpcpp_nn/modules.py
@@ -14,6 +14,9 @@ MIN_BATCH_SIZE = 8  # in tiny-dpcpp-nn the smallest possible batch size is 8
 
 torch.set_printoptions(precision=2)
 
+def free_temporary_memory():
+    """Dummy function for compatibility"""
+    pass
 
 def unpad_tensor_to_input_dim(padded_tensor, output_dim):
     batch_size, current_width = padded_tensor.shape


### PR DESCRIPTION
Expose a dummy function free_temporary_memory() to the python interface for compatibility