### PR TITLE
make config validity check optional

### DIFF
--- a/include/encodings/encoding.h
+++ b/include/encodings/encoding.h
@@ -41,6 +41,7 @@ struct EncodingParams {
     inline static const std::string HASH = "hash";                                 // HashType
     inline static const std::string INTERPOLATION_METHOD = "interpolation";        // InterpolationType
     inline static const std::string USE_STOCHASTIC_INTERPOLATION = "stochastic_interpolation"; // bool
+    inline static const std::string CHECK_CONFIG = "check_config";                 // bool
 };
 
 struct EncodingNames {

--- a/include/encodings/encoding_factory.h
+++ b/include/encodings/encoding_factory.h
@@ -103,6 +103,9 @@ template <typename T> class EncodingFactoryRegistry {
 };
 
 void check_validity_of_config(const json &config) {
+    if( !config.contains(EncodingParams::CHECK_CONFIG) || config[EncodingParams::CHECK_CONFIG] == false ) {
+        return;
+    }
     // Define a list of all possible encoding parameters, see encoding.h
     const std::vector<std::string> valid_keys = {
         EncodingParams::ENCODING,
@@ -120,6 +123,7 @@ void check_validity_of_config(const json &config) {
         EncodingParams::HASH,
         EncodingParams::INTERPOLATION_METHOD,
         EncodingParams::USE_STOCHASTIC_INTERPOLATION,
+        EncodingParams::CHECK_CONFIG,
     };
 
     // Check if every key in the config is within the valid keys


### PR DESCRIPTION
Make the config validity check optional for compatibility. The check can be enabled with the "check_config " key.